### PR TITLE
add docker and docker-compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,22 @@ WORKDIR /tableaunoir/
 # Copy source code.
 COPY . .
 
+# Put recognizable variable names
+# in config.json for replacement
+# in tableaunoir.js after build.
+RUN echo "{"\
+    "\"server\": {"\
+        "\"websocket\": \"EXTERNAL_WS_URL\","\
+        "\"frontend\": \"EXTERNAL_HTTP_URL\""\
+    "}"\
+"}"\
+> /tableaunoir/src/config.json
+
+
+# Copy entrypoint at root for easier accesss.
+COPY docker/entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
 # Update npm.
 RUN npm install -g npm@latest
 
@@ -18,6 +34,5 @@ ENV PATH="/node_modules/.bin:${PATH}"
 # Build everything to dist.
 RUN npm run build
 
-USER node
 EXPOSE 8080
-CMD node /tableaunoir/server/main.js
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:15-buster
+
+WORKDIR /tableaunoir/
+
+# Copy source code.
+COPY . .
+
+# Update npm.
+RUN npm install -g npm@latest
+
+# Install tableaunoir dependencies.
+RUN npm install --only=dev
+RUN npm install ws small-uuid 
+
+# Include node modules binaries in PATH. 
+ENV PATH="/node_modules/.bin:${PATH}"
+
+# Build everything to dist.
+RUN npm run build
+
+USER node
+EXPOSE 8080
+CMD node /tableaunoir/server/main.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,27 @@
 version: '3.8'
 services:
-  backend:
-    container_name: backend
+  tableaunoir:
+    container_name: tableaunoir
     image: tableaunoir:latest
     restart: unless-stopped
+    environment:
+      - EXTERNAL_WS_URL="ws://127.0.0.1:8181"
+      - EXTERNAL_HTTP_URL="http://127.0.0.1:8182"
     volumes:
       - /tableaunoir
+    networks:
+      - tableaunoir
+  backend:
+    container_name: backend
+    image: nginx:1.19
+    restart: unless-stopped
+    volumes:
+      - ./docker/templates/backend:/etc/nginx/templates:ro
+    ports:
+      - 8181:80
+    environment:
+      - NGINX_HOST=127.0.0.1
+      - NGINX_PORT=80
     networks:
       - tableaunoir
   frontend:
@@ -13,7 +29,7 @@ services:
     image: nginx:1.19
     restart: unless-stopped
     volumes_from:
-      - backend:ro
+      - tableaunoir:ro
     volumes:
       - ./docker/templates/frontend:/etc/nginx/templates:ro
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  backend:
+    container_name: backend
+    image: tableaunoir:latest
+    restart: unless-stopped
+    volumes:
+      - /tableaunoir
+    networks:
+      - tableaunoir
+  frontend:
+    container_name: frontend
+    image: nginx:1.19
+    restart: unless-stopped
+    volumes_from:
+      - backend:ro
+    volumes:
+      - ./docker/templates/frontend:/etc/nginx/templates:ro
+    ports:
+      - 8182:80
+    environment:
+      - NGINX_HOST=127.0.0.1
+      - NGINX_PORT=80
+    networks:
+      - tableaunoir
+networks:
+    tableaunoir:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+echo "EXTERNAL_WS_URL=$EXTERNAL_WS_URL"
+echo "EXTERNAL_HTTP_URL=$EXTERNAL_HTTP_URL"
+
+sed -i "s|EXTERNAL_WS_URL|$EXTERNAL_WS_URL|g" /tableaunoir/src/config.json
+sed -i "s|EXTERNAL_HTTP_URL|$EXTERNAL_HTTP_URL|g" /tableaunoir/src/config.json
+sed -i "s|EXTERNAL_WS_URL|$EXTERNAL_WS_URL|g" /tableaunoir/dist/tableaunoir.js
+sed -i "s|EXTERNAL_HTTP_URL|$EXTERNAL_HTTP_URL|g" /tableaunoir/dist/tableaunoir.js
+
+chmod 0644 /tableaunoir/src/config.json
+
+node /tableaunoir/server/main.js

--- a/docker/templates/backend/default.conf.template
+++ b/docker/templates/backend/default.conf.template
@@ -1,0 +1,29 @@
+upstream tableaunoir {
+  server tableaunoir:8080;  # Or whatever port the backend in listening on
+}
+
+server {
+
+  listen ${NGINX_PORT};
+  listen [::]:${NGINX_PORT};
+
+  # Different host name for convenience
+  server_name ${NGINX_HOST};
+
+  # SSL config, you might want to take a look https://ssl-config.mozilla.org/
+  # to set other configuration parameters.
+  #ssl_certificate /path/to/certificate;
+  #ssl_certificate_key /path/to/certificate/key;
+
+  root /dev/null;
+
+  # http://nginx.org/en/docs/http/websocket.html
+  location / {
+    #include proxy_params;
+    proxy_pass http://tableaunoir;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+
+}

--- a/docker/templates/frontend/default.conf.template
+++ b/docker/templates/frontend/default.conf.template
@@ -1,0 +1,19 @@
+server {
+
+  listen ${NGINX_PORT};
+  listen [::]:${NGINX_PORT};
+
+  server_name ${NGINX_HOST};
+
+  root /tableaunoir/dist;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ =404;
+  }
+
+  # Optional: you might not want to serve these folders
+  location /server { return 404; }
+  location /.git   { return 404; }
+
+}


### PR DESCRIPTION
This add a base Dockerfile to build a Docker image and a docker-compose file to run it in a container.

Build with:
```bash
docker image build . -t tableaunoir:latest
```

or `-t aDockerHubInstance\tableaunoir:latest`.

Run with:
```bash
docker-compose up -d
```