### PR TITLE
Using the localStorage API instead of keys

### DIFF
--- a/src/ChalkCursor.ts
+++ b/src/ChalkCursor.ts
@@ -4,7 +4,7 @@ import { OptionManager } from './OptionManager';
 export class ChalkCursor {
 
     /** undefined for right-handed, "true" for left-handed */
-    static leftHanded = localStorage.getItem("leftHanded");
+    static leftHanded = localStorage.getItem("leftHanded") === null;
 
 
     /**

--- a/src/LoadSave.ts
+++ b/src/LoadSave.ts
@@ -25,8 +25,8 @@ export class LoadSave {
      */
     static loadFromLocalStorage(): void {
         const name = Share.getTableauNoirID();
-        if (localStorage[name])
-            LoadSave.loadJSON(JSON.parse(localStorage[name]));
+        if (localStorage.getItem(name))
+            LoadSave.loadJSON(JSON.parse(localStorage.getItem(name)));
     }
 
 
@@ -36,7 +36,7 @@ export class LoadSave {
      */
     static saveLocalStorage(): void {
         const name = Share.getTableauNoirID();
-        localStorage[name] = LoadSave.getTableauNoirString();
+        localStorage.setItem(name, LoadSave.getTableauNoirString());
     }
 
     /**

--- a/src/OptionManager.ts
+++ b/src/OptionManager.ts
@@ -42,12 +42,12 @@ export class OptionManager {
     //static boolean({name: string, onChangeCallBack: (boolean) => void}): void {
     static boolean({ name, defaultValue, onChange }: { name: string, defaultValue: boolean, onChange: (boolean) => void }): void {
         const el = OptionManager.getInputElement(name);
-        const initialValue = (localStorage[name] == undefined) ? defaultValue : parseBoolean(localStorage[name]);
-        //console.log(`reading option ${name}: ${localStorage[name]}`)
+        const initialValue = localStorage.getItem(name) === null ? defaultValue : parseBoolean(localStorage.getItem(name));
+        //console.log(`reading option ${name}: ${localStorage.getItem(name)}`)
         el.checked = initialValue;
         onChange(el.checked);
         el.onchange = () => {
-            localStorage[name] = el.checked;
+            localStorage.setItem(name, el.checked.toString());
             onChange(el.checked);
         };
     }
@@ -60,17 +60,17 @@ export class OptionManager {
     }
 
     static string({ name, defaultValue, onChange }: { name: string, defaultValue: string, onChange: (string) => void }): void {
-        const initialValue: string = (localStorage[name] == undefined) ? defaultValue : localStorage[name];
+        const initialValue: string = (localStorage.getItem(name) === null) ? defaultValue : localStorage.getItem(name);
         const el = OptionManager.getInputElement(name);
 
         onChange(initialValue);
 
         if (el != undefined) {
-            //console.log(`reading option ${name}: ${localStorage[name]}`)
+            //console.log(`reading option ${name}: ${localStorage.getItem(name)}`)
             el.value = initialValue;
 
             el.oninput = () => {
-                localStorage[name] = el.value;
+                localStorage.setItem(name, el.value.toString());
                 onChange(el.value);
             };
         }
@@ -82,7 +82,7 @@ export class OptionManager {
                 if (radioInput.value == initialValue)
                     radioInput.checked = true;
                 radioInput.onclick = () => {
-                    localStorage[name] = radioInput.value;
+                    localStorage.setItem(name, radioInput.value.toString());
                     onChange(radioInput.value);
                 };
             }
@@ -93,12 +93,12 @@ export class OptionManager {
 
     static number({ name, defaultValue, onChange }: { name: string, defaultValue: number, onChange: (number) => void }): void {
         const el = OptionManager.getInputElement(name);
-        const initialValue = (localStorage[name] == undefined) ? defaultValue : localStorage[name];
-        //console.log(`reading option ${name}: ${localStorage[name]}`)
+        const initialValue = localStorage.getItem(name) ?? defaultValue;
+        //console.log(`reading option ${name}: ${localStorage.getItem(name)}`)
         el.value = "" + initialValue;
         onChange(el.value);
         el.oninput = () => {
-            localStorage[name] = el.value;
+            localStorage.setItem(name, el.value);
             onChange(el.value);
         };
     }


### PR DESCRIPTION
LocalStorage is intended to be interacted with through the API rather than mutating the LocalStorage object itself. The API is stable and doesn't seem likely to change anytime soon and also has no odd gotchas so it's good practice to use it.