### PR TITLE
Eval usage removed, palette switching bugfix

### DIFF
--- a/src/Palette.ts
+++ b/src/Palette.ts
@@ -1,16 +1,20 @@
 import { CircularMenu } from './CircularMenu';
 import { ChalkCursor } from './ChalkCursor';
 import { OptionManager } from './OptionManager';
+import { standard, crazy } from './Palettes';
+import type { PaletteNames } from './Palettes';
 
 /**
  * the circular palette
  */
 export class Palette extends CircularMenu {
 
-    private static defaultColorSet = '["white", "yellow", "orange", "rgb(100, 172, 255)", "Crimson", "Plum", "LimeGreen", "black"]'
+    private palettes: { standard: string[], crazy: string[] } = {
+        standard, crazy
+    }
 
     /** colors that can have a chalk. The first color *must* be white */
-    private colors: string[] = eval(Palette.defaultColorSet);
+    private colors: string[] = standard;
 
     private currentColorID = 0;
     onchange: () => void = () => {
@@ -22,10 +26,10 @@ export class Palette extends CircularMenu {
         super();
         setTimeout(() => OptionManager.string({
             name: "palette",
-            defaultValue: Palette.defaultColorSet,
-            onChange: (s) => {
-                //console.log("change colors of the palette")
-                this.colors = eval(s);
+            defaultValue: "standard",
+            onChange: (newPaletteName: PaletteNames ) => {
+                this.colors = this.palettes[newPaletteName];
+                this.currentColorID = 0;
                 this._createPalette();
             }
         }), 1000);

--- a/src/Palettes.ts
+++ b/src/Palettes.ts
@@ -1,0 +1,38 @@
+export type PaletteNames = "standard" | "crazy"
+
+export const standard = [
+  "white",
+  "yellow",
+  "orange",
+  "rgb(100, 172, 255)",
+  "Crimson",
+  "Plum",
+  "LimeGreen",
+  "black"
+];
+
+export const crazy = [
+  "white", 
+  "#BBBBBB",
+  "#888888",
+  "#444444",
+  "black",
+  "#FFFF00",
+  "#FFBB00",
+  "#FF8800",
+  "#FF5500",
+  "#FF0000",
+  "#CC0000",
+  "#880000",
+  "#8800FF",
+  "#FF00FF",
+  "#FFAAFF",
+  "#FFCCFF",
+  "#0000FF",
+  "#0088FF",
+  "#00FFFF",
+  "#88FF88",
+  "#00FF00",
+  "#008800",
+  "#558800"
+];

--- a/src/index.html
+++ b/src/index.html
@@ -438,32 +438,10 @@
 				</helpbutton>
 				<br /><br />
 
-				<input type="radio" id="inputPaletteStandard" name="inputPalette"
-					value='["white", "yellow", "orange", "rgb(100, 172, 255)", "Crimson", "Plum", "LimeGreen", "black"]'><label
-					for="inputPaletteStandard">Standard 8 color palette</label><br />
-				<input type="radio" id="inputPaletteCrazy" name="inputPalette" value='["white", 
-    "#BBBBBB",
-    "#888888",
-    "#444444",
-    "black",
-    "#FFFF00",
-    "#FFBB00",
-    "#FF8800",
-    "#FF5500",
-    "#FF0000",
-    "#CC0000",
-    "#880000",
-    "#8800FF",
-    "#FF00FF",
-    "#FFAAFF",
-    "#FFCCFF",
-    "#0000FF",
-    "#0088FF",
-    "#00FFFF",
-    "#88FF88",
-    "#00FF00",
-    "#008800",
-    "#558800"]'><label for="inputPaletteCrazy">21 color palette</label><br />
+				<input type="radio" id="inputPaletteStandard" name="inputPalette" value="standard">
+				<label for="inputPaletteStandard">Standard 8 color palette</label><br />
+				<input type="radio" id="inputPaletteCrazy" name="inputPalette" value="crazy">
+				<label for="inputPaletteCrazy">21 color palette</label><br />
 				<div class="onlyForDesktop">
 					<h2>✐✎ <span>Cursor</span></h2>
 					<input type="checkbox" id="inputLeftHanded" /><label for="inputLeftHanded">Left-handed</label>


### PR DESCRIPTION
Eval is generally not good practice to use, especially not when `nodeIntegration` is turned on in Electron. I can't see any way to exploit it but I'm not a penterster so it's not a very good measure of risk. It's best to avoid it if possible.

Also fixes issue #242.