### PR TITLE
Left menu mobile mode

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -162,27 +162,27 @@
 		<div class="tabs">
 			<button class="tablink" id="defaultOpen" onclick="Menu.openPage('MyBlackboard', this)">
 				<img src="img/icons/board.svg" alt="My board" />
-				<span>My Board</span>
+				<span class="tablinkLabel">My Board</span>
 			</button>
 			<button class="tablink" id="tabShare" onclick="Menu.openPage('Share', this)">
 				<img src="img/icons/link.svg" alt="share" />
-				<span>Share</span>
+				<span class="tablinkLabel">Share</span>
 			</button>
 			<button class="tablink" onclick="Menu.openPage('Background', this)">
 				<img src="img/icons/palette.svg" alt="background" />
-				<span>Background</span>
+				<span class="tablinkLabel">Background</span>
 			</button>
 			<button class="tablink" onclick="Menu.openPage('Magnets', this)">
 				<img src="img/icons/magnet.svg" alt="magnets" />
-				<span>Magnets</span>
+				<span class="tablinkLabel">Magnets</span>
 			</button>
 			<button class="tablink onlyForDesktop" onclick="Menu.openPage('ScriptTab', this)">
 				<img src="img/icons/codebraces.svg" alt="scripts" />
-				<span>Script</span>
+				<span class="tablinkLabel">Script</span>
 			</button>
 			<button class="tablink" onclick="Menu.openPage('Options', this)">
 				<img src="img/icons/settings.svg" alt="settings" />
-				<span>Options</span>
+				<span class="tablinkLabel">Options</span>
 			</button>
 			<button class="tablink onlyForDesktop" onclick="Menu.openPage('KeyboardShortcuts', this)" id="defaultOpen">
 				<img src="img/icons/keyboard.svg" alt="shortcuts" />
@@ -190,11 +190,11 @@
 			</button>
 			<button class="tablink" onclick="Menu.openPage('Help', this)" id="defaultOpen">
 				<div>?</div>
-				<span>Help</span>
+				<span class="tablinkLabel">Help</span>
 			</button>
 			<button class="tablink" onclick="Menu.openPage('About', this)" id="defaultOpen">
 				<img src="img/icons/about.svg" alt="about" />
-				About tableaunoir
+				<span class="tablinkLabel">About tableaunoir</span>
 			</button>
 		</div>
 		<div style="user-select: text;">

--- a/src/style.css
+++ b/src/style.css
@@ -1218,6 +1218,15 @@ h1 {
 		width: 128px;
 		padding-left: 16px;
 	}
+
+	.tablinkLabel {
+		display: none;
+	}
+
+	.tablink {
+		width: min-content;
+		min-width: 0;
+	}
 }
 
 


### PR DESCRIPTION
Makes the left hand menu shrink down to icons only once the screen is narrow enough. Primarily useful on smartphones.

![mobile menu](https://user-images.githubusercontent.com/3480318/226433349-c256183d-9466-4c18-8bb6-bb0f7358d163.png)
