### PR TITLE
Menu mobile mode pr

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -186,7 +186,7 @@
 			</button>
 			<button class="tablink onlyForDesktop" onclick="Menu.openPage('KeyboardShortcuts', this)" id="defaultOpen">
 				<img src="img/icons/keyboard.svg" alt="shortcuts" />
-				<span class="longText">Keyboard Shortcuts</span>
+				<span class="longText tablinkLabel">Keyboard Shortcuts</span>
 			</button>
 			<button class="tablink" onclick="Menu.openPage('Help', this)" id="defaultOpen">
 				<div>?</div>

--- a/src/index.html
+++ b/src/index.html
@@ -162,27 +162,27 @@
 		<div class="tabs">
 			<button class="tablink" id="defaultOpen" onclick="Menu.openPage('MyBlackboard', this)">
 				<img src="img/icons/board.svg" alt="My board" />
-				<span>My Board</span>
+				<span class="tablinkLabel">My Board</span>
 			</button>
 			<button class="tablink" id="tabShare" onclick="Menu.openPage('Share', this)">
 				<img src="img/icons/link.svg" alt="share" />
-				<span>Share</span>
+				<span class="tablinkLabel">Share</span>
 			</button>
 			<button class="tablink" onclick="Menu.openPage('Background', this)">
 				<img src="img/icons/palette.svg" alt="background" />
-				<span>Background</span>
+				<span class="tablinkLabel">Background</span>
 			</button>
 			<button class="tablink" onclick="Menu.openPage('Magnets', this)">
 				<img src="img/icons/magnet.svg" alt="magnets" />
-				<span>Magnets</span>
+				<span class="tablinkLabel">Magnets</span>
 			</button>
 			<button class="tablink onlyForDesktop" onclick="Menu.openPage('ScriptTab', this)">
 				<img src="img/icons/codebraces.svg" alt="scripts" />
-				<span>Script</span>
+				<span class="tablinkLabel">Script</span>
 			</button>
 			<button class="tablink" onclick="Menu.openPage('Options', this)">
 				<img src="img/icons/settings.svg" alt="settings" />
-				<span>Options</span>
+				<span class="tablinkLabel">Options</span>
 			</button>
 			<button class="tablink onlyForDesktop" onclick="Menu.openPage('KeyboardShortcuts', this)" id="defaultOpen">
 				<img src="img/icons/keyboard.svg" alt="shortcuts" />
@@ -190,11 +190,11 @@
 			</button>
 			<button class="tablink" onclick="Menu.openPage('Help', this)" id="defaultOpen">
 				<div>?</div>
-				<span>Help</span>
+				<span class="tablinkLabel">Help</span>
 			</button>
 			<button class="tablink" onclick="Menu.openPage('About', this)" id="defaultOpen">
 				<img src="img/icons/about.svg" alt="about" />
-				About tableaunoir
+				<span class="tablinkLabel">About tableaunoir</span>
 			</button>
 		</div>
 		<div style="user-select: text;">

--- a/src/style.css
+++ b/src/style.css
@@ -1218,6 +1218,15 @@ h1 {
 		width: 128px;
 		padding-left: 16px;
 	}
+
+	.tablinkLabel {
+		display: none;
+	}
+
+	.tablink {
+		width: min-content;
+		min-width: 0;
+	}
 }
 
 

--- a/src/style.css
+++ b/src/style.css
@@ -1203,7 +1203,16 @@ h1 {
 	}
 }
 
+@media only screen and (orientation: portrait) {
+	.tablinkLabel {
+		display: none;
+	}
 
+	.tablink {
+		width: min-content;
+		min-width: 0;
+	}
+}
 
 
 @media only screen and (max-width: 768px) {


### PR DESCRIPTION
Collapse the left menu while on a mobile device or when the screen gets narrow enough. I've been a bit broad when the collapse rule triggers since no functionality is really lost when it does.

![mobile](https://user-images.githubusercontent.com/3480318/226586315-25c5b144-9089-40fb-80d8-ad1e4f0d3456.png)
![small desktop](https://user-images.githubusercontent.com/3480318/226586323-aa222b47-5932-4177-a582-155a80b6fee6.png)
