### PR TITLE
Replaced malicious polyfill.io with cloudflare drop-in replacement.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<link rel="manifest" href="/manifest.webmanifest">
 	<link rel="stylesheet" type="text/css" href="style.css" />
-	<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+	<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=es6"></script>
 	<script src="./tableaunoir.js"></script>
 	<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </head>


### PR DESCRIPTION
Polyfill.io has been sold to new owner and can no longer be trusted. They have already abused their position to redirect people as describe [this Cloudflare blog post](https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet). They, Cloudflare, have a good reputation and are offering a drop-in replacement.

The replacement is a suggestion and an easy fix but if you wish not to trust Cloudflare there might be other options out there however polyfill.io should never be trusted again.