### PR TITLE
Fixup linting on the Typescript code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,13 +16,23 @@ module.exports = {
         "@typescript-eslint"
     ],
     "rules": {
+      "@typescript-eslint/no-require-imports": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-this-alias": "off",
       "no-mixed-spaces-and-tabs": "warn",
       "no-self-assign": "warn",
       "no-empty": "warn",
-      "@typescript-eslint/ban-types": "warn",
+      "@typescript-eslint/no-empty-object-type": "warn",
+      "@typescript-eslint/no-unsafe-function-type": "warn",
+      "@typescript-eslint/no-wrapper-object-types": "warn",
       "@typescript-eslint/no-empty-function": "warn",
       "@typescript-eslint/no-inferrable-types": "warn",
       "no-var": "warn",
-      "prefer-const": "warn"
+      "prefer-const": "warn",
+      "@typescript-eslint/no-unused-vars": ["warn", {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_"
+      }]
     }
 };

--- a/src/ActionWait.ts
+++ b/src/ActionWait.ts
@@ -1,4 +1,3 @@
-import { Drawing } from './Drawing';
 import { ActionSerialized } from './ActionSerialized';
 import { Action } from './Action';
 import { AnimationManager } from './AnimationManager';

--- a/src/AnimationToolBar.ts
+++ b/src/AnimationToolBar.ts
@@ -118,7 +118,7 @@ export class AnimationToolBar {
         if (isCurrentSlide)
             slide.classList.add("slideCurrent");
 
-        const actionIndex = (evt) => {
+        const actionIndex = (_evt) => {
             /*  if (isCurrentSlide) {
                   const x = evt.clientX - slide.offsetLeft;
                   return from + Math.round(x * (to - from) / slide.clientWidth);
@@ -367,7 +367,7 @@ export class AnimationToolBar {
      * @param t 
      * @returns update and take into account that the action n° t has been removed
      */
-    static updateDeleteAction(t: number): void {
+    static updateDeleteAction(_t: number): void {
         if (!AnimationToolBar.is())
             return;
 
@@ -380,7 +380,7 @@ export class AnimationToolBar {
      * @param index 
      * @description update the timeline bar given that there was only the insertion of action at index that have been produced
      */
-    static updateAddAction(index: number): void {
+    static updateAddAction(_index: number): void {
         if (!AnimationToolBar.is())
             return;
 

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -230,7 +230,7 @@ export class Layout {
         Layout.getWindowHeight = () => { return Layout.STANDARDHEIGHT; };
         Layout.getWindowWidth = () => { return window.innerWidth * Layout.getZoom(); };
         Layout.getZoom = () => {
-            const toolbar = Toolbar.getToolbar();
+            const _toolbar = Toolbar.getToolbar();
             //       const innerHeight = window.innerHeight - (Toolbar.isHidden() ? 0 : toolbar.clientHeight);
             //  if (toolbar.clientHeight < window.innerHeight / 10 || Toolbar.left || Toolbar.right) {
             const heightused = window.innerHeight;

--- a/src/LoadSave.ts
+++ b/src/LoadSave.ts
@@ -101,7 +101,7 @@ export class LoadSave {
          * "error" otherwise
          */
         function getTypeFilesDrag(event): "tableaunoir" | "images" | "error" {
-            let containsImages = false;
+            let _containsImages = false;
             let containsTableaunoir = false;
             let containsError = false;
             let count = 0;
@@ -110,7 +110,7 @@ export class LoadSave {
                 if (file.name.endsWith(".tableaunoir"))
                     containsTableaunoir = true;
                 else if (file.name.endsWith(".png") || file.name.endsWith(".jpg") || file.name.endsWith(".gif") || file.name.endsWith(".svg"))
-                    containsImages = true;
+                    _containsImages = true;
                 else
                     containsError = true;
                 count++;

--- a/src/MagnetTextManager.ts
+++ b/src/MagnetTextManager.ts
@@ -15,7 +15,7 @@ import hljs from 'highlight.js';
 class MarkdownMagnet extends HTMLElement {
 
 	private connectedCallback() {
-		const shadow = this.attachShadow({
+		const _shadow = this.attachShadow({
 			mode: 'open',
 			delegatesFocus: true // so that Firefox understands when the focus is removed from the text magnet (the editor)
 		});
@@ -97,7 +97,7 @@ class MarkdownMagnet extends HTMLElement {
 			Share.execute("magnetChange", [UserManager.me.userID, element.id, element.outerHTML]);
 		}
 
-		divCode.addEventListener('focusout', (e) => { validate(); });
+		divCode.addEventListener('focusout', (_evt) => { validate(); });
 
 
 		divCode.onkeydown = (e) => {
@@ -187,8 +187,8 @@ class MarkdownMagnet extends HTMLElement {
 	 * access to the HTML element corresponding respectively to the editor (in the code edition mode)
 	 * and the rendering element (for the rendering mode)
 	 */
-	private get editorElement() { return <HTMLElement>this.shadowRoot.children[2] };
-	private get renderingElement() { return <HTMLElement>this.shadowRoot.children[3] };
+	private get editorElement() { return <HTMLElement>this.shadowRoot.children[2] }
+	private get renderingElement() { return <HTMLElement>this.shadowRoot.children[3] }
 
 
 	/**
@@ -217,7 +217,7 @@ const marked = new Marked(
 	markedHighlight({
 		emptyLangClass: 'hljs',
 		langPrefix: 'hljs language-',
-		highlight(code, lang, info) {
+		highlight(code, lang, _info) {
 			const language = hljs.getLanguage(lang) ? lang : 'plaintext';
 			return hljs.highlight(code, { language }).value;
 		}
@@ -245,7 +245,7 @@ export class MagnetTextManager {
 		try {
 			(<any>window).MathJax.typeset([element]);
 			//	eval("MathJax.typeset();");
-		} catch (e) { console.log("MathJaX not supported"); }
+		} catch (_err) { console.log("MathJaX not supported"); }
 	}
 	/**
 	 * 

--- a/src/Magnetizer.ts
+++ b/src/Magnetizer.ts
@@ -1,6 +1,5 @@
 import { Sound } from './Sound';
 import { ActionClearZone } from './ActionClearZone';
-import { UserManager } from './UserManager';
 import { BoardManager } from './boardManager';
 import { getCanvas } from './main';
 import { MagnetManager } from './magnetManager';

--- a/src/MinHeap.ts
+++ b/src/MinHeap.ts
@@ -3,7 +3,7 @@
  */
 export class MinHeap {
 
-    private heap: Object[];
+    private heap: object[];
     private priority: number[];
     private indices;
     /**

--- a/src/OperationTranslate.ts
+++ b/src/OperationTranslate.ts
@@ -1,5 +1,4 @@
 import { BoardManager } from "./boardManager";
-import { Action } from "./Action";
 import { Operation } from "./Operation";
 import { ActionFreeDraw } from "./ActionFreeDraw";
 import { ActionErase } from "./ActionErase";

--- a/src/ToolDraw.ts
+++ b/src/ToolDraw.ts
@@ -1,4 +1,3 @@
-import { OptionManager } from './OptionManager';
 import { MagnetManager } from './magnetManager';
 import { UserManager } from './UserManager';
 import { ActionFreeDraw } from './ActionFreeDraw';

--- a/src/Toolbar.ts
+++ b/src/Toolbar.ts
@@ -28,6 +28,7 @@ export class Toolbar {
                 }
             }
             catch (e) {
+                console.log("Error loading the toolbar: ", e)
                 ShowMessage.error("Error in loading the toolbar. You can however use Tableaunoir.")
             }
 

--- a/src/boardManager.ts
+++ b/src/boardManager.ts
@@ -214,6 +214,7 @@ export class BoardManager {
             BoardManager.timeline.clearAndReset(canvasDataURL);
         }
         catch (e) {
+            console.log("Error while loading board from local storage: ", e)
             //TODO: handle error?
         }
     }
@@ -224,7 +225,7 @@ export class BoardManager {
     /**
      * @description cancel the previous operation on the cancel stack
      */
-    static async cancel(userid: string): Promise<void> {
+    static async cancel(_userid: string): Promise<void> {
         if (!BoardManager.cancelStack.canUndo())
             return;
 
@@ -237,7 +238,7 @@ export class BoardManager {
     /**
      * @description redo the next operation on the cancel stack
      */
-    static async redo(userid: string): Promise<void> {
+    static async redo(_userid: string): Promise<void> {
         if (!BoardManager.cancelStack.canRedo())
             return;
 
@@ -357,7 +358,7 @@ export class BoardManager {
      * @param userid 
      * @description remove the next pause action for merging the current slide with the next one
      */
-    static mergeSlide(userid: string): void {
+    static mergeSlide(_userid: string): void {
         const nextNewSlideActionIndex = BoardManager.timeline.getNextNewSlideActionIndex();
         if (nextNewSlideActionIndex)
             BoardManager.executeOperation(new OperationDeleteSeveralActions([nextNewSlideActionIndex]));
@@ -421,7 +422,7 @@ export class BoardManager {
 
                         if (iPrint) {
 
-                            const actionPrintMagnet = timeline.actions[iPrint];
+                            const _actionPrintMagnet = timeline.actions[iPrint];
 
                             const iMove = indicesSuchThat(timeline.actions, j, iPrint, (a) =>
                                 a instanceof ActionMagnetMove && a.magnetid == magnetid);

--- a/src/magnetManager.ts
+++ b/src/magnetManager.ts
@@ -1,5 +1,4 @@
 import { S } from './Script';
-import { MagnetTextManager } from './MagnetTextManager';
 import { ActionMagnetDelete } from './ActionMagnetDelete';
 import { ActionMagnetNew } from './ActionMagnetNew';
 import { Sound } from './Sound';
@@ -740,7 +739,7 @@ export class MagnetManager {
 		BoardManager.addAction(new ActionMagnetDelete(UserManager.me.userID, id));
 		//		document.getElementById(id).remove(); //do not remove here because ActionMagnetDelete is doing the job in add Action
 		//		document.getElementById(id).style.top = "-1000";
-		MagnetManager.currentMagnet == undefined;
+		MagnetManager.currentMagnet = undefined;
 		MagnetManager.magnetUnderCursor = undefined;
 		ConstraintDrawing.update();
 	}

--- a/src/share.ts
+++ b/src/share.ts
@@ -124,6 +124,7 @@ export class Share {
 					}
 				}
 				catch (e) {
+					console.log("Error tryjoin from shared url: ", e)
 					Share.ws = undefined;
 					Share.showConnectionError();
 				}
@@ -206,6 +207,7 @@ export class Share {
 			Share.setRoot(UserManager.me.userID);
 		}
 		catch (e) {
+			console.log("Error share: ", e)
 			Share.ws = undefined;
 			Share.showConnectionError();
 		}


### PR DESCRIPTION
# Why
Because I use your project for my courses, but am not good at writing Javascript / Typescript, I wanted to have the linting working well so that I can constantly see if I propose crappy code to your project.

But right now the `npm run lint` already raises many issues

Feel free to deny some changes, and ask me if you want me to adapt the changes made.
Also, I can keep these changes locally for my own fork, and not merge these in your repo if that's annoying to you, no worries

# What did I do
- On `src/magnetManager.ts`, the `== undefined` instead of `= undefined` may cause a bug currently, so that's a catch

- All the unused variables, I don't know what is your intent behind, so I just added a rule in `eslint` that ignores unused variables if they start with a `_` (that's what is done in Rust).
This way you can still easily find any variable that isn't currently used, but I didn't remove any code that may be used in the future.

- Some things you are doing are apparently frowned upon (`element = this`, use of `<any>`), but I don't know what is happening so I just turned off linting for them

- Some imports weren't used, so I allowed myself to delete these extra imports

- When catching errors, the errors weren't used, so I just logged them to console (but we could just ignore them with a `_` prefix)

- The eslint rule `@typescript-eslint/ban-types` is deprecated (see https://typescript-eslint.io/rules/ban-types/), so I changed it to what is recommended on the website

- Also removed trailing `;` that apparently aren't useful, and changed `Object[]` to `object[]` because apparently it's wrong to do so.