### PR TITLE
Fix remote user able to write on table even if not write perm

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -205,9 +205,11 @@ function installMouseEventsCanvas() {
 					isToolTemporarilySwitchedToErase = false;
 			}
 
-			isCurrentlyMouseDown = true;
-			window["ismousedown"] = true;
-			Share.execute("mousedown", [UserManager.me.userID, evt])
+			if (UserManager.me.canWrite) {
+				isCurrentlyMouseDown = true;
+				window["ismousedown"] = true;
+				Share.execute("mousedown", [UserManager.me.userID, evt])
+			}
 		}
 	};
 


### PR DESCRIPTION
Fixes a bug:

When a remote user doesn't have the permission to write on the board:
- It can still write, but nothing appears on their side
- But something appears on my side
- The trace that appears is very "polygonal", as if only half of the event goes through.

I don't really understand what is the problem, but that's on the websocket server side, but didn't figured it out
So I fixed the problem on the client side.

That still allows bad hackers to send the packets and display something on the board, bypassing the restriction on the client side, but that's a first dirty fix for most of the cases :sweat_smile: 