### PR TITLE
Set average pressure of all points in Douglas Peucker algorithm

### DIFF
--- a/src/ActionFreeDraw.ts
+++ b/src/ActionFreeDraw.ts
@@ -203,29 +203,32 @@ export class ActionFreeDraw extends Action {
             // Find the point with the maximum distance
             let dmax = 0
             let ifar = 0
+            let sum_pressure = 0
 
             for (let i = begin; i < end; i++) {
                 const d = perpendicularDistance(this.points[i], this.points[begin], this.points[end]);
+                sum_pressure += this.points[i].pressure
                 if (d > dmax) {
                     ifar = i;
                     dmax = d;
                 }
             }
+            let avg_pressure = sum_pressure / (end - begin);
 
             if (dmax > EPSILON) {
                 const A1 = DouglasPeucker(begin, ifar)
                 const A2 = DouglasPeucker(ifar, end);
                 return A1.concat(A2.slice(1));
-            } else
-                return [this.points[begin], this.points[end]];
-
+            } else {
+                let a = this.points[begin]
+                a.pressure = avg_pressure
+                let b = this.points[end]
+                b.pressure = avg_pressure
+                return [a, b];
+            }
         }
 
         this.points = DouglasPeucker(0, this.points.length - 1);
-
-        //fix of the pressure at the end (otherwise there is a weird end in the draw)
-        if (this.points.length >= 2)
-            this.points[this.points.length - 1].pressure = this.points[this.points.length - 2].pressure;
     }
 
 


### PR DESCRIPTION
When drawing little lines on the board (ex: letter "t" or the point in "i"), sometimes it draws them very very thin, which requires to make another pass to have the same width on the whole word

I don't fully understand the Douglas Peucker algorithm, but I think it's because it the choice of the points is poor (ex: firsts and lasts), it can be a subset with very light pressure, which will in turn be applied to the whole line, making it super thin.

Because in any case we iterate through all the points,  I use this opportunity to compute a simple average of the pressure, and apply it to the 2 points selected.

That also seams to fix the bug you had with the weird end pressure.

Again, I do not fully understand the algorithm, can coded myself a hack, so that may require much more thoughts on how to implement this properly